### PR TITLE
Refactor dataset paths in forecasting notebook

### DIFF
--- a/binance_forecasting.ipynb
+++ b/binance_forecasting.ipynb
@@ -31,6 +31,7 @@
    "source": [
     "# Standard libraries\n",
     "import os\n",
+    "from pathlib import Path\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "from datetime import datetime\n"
@@ -46,7 +47,7 @@
     "# Path to your data directory on Google Drive\n",
     "# Update this path to where you've stored the Binance data files\n",
     "# For example: '/content/drive/MyDrive/binance_data'\n",
-    "data_dir = '/content/drive/MyDrive/binance_data'\n"
+    "data_dir = Path('/content/drive/MyDrive/binance_data')\n"
    ]
   },
   {
@@ -56,16 +57,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Dictionary mapping dataset keys to file names located in `data_dir`\n",
-    "files = {\n",
-    "    'aggtrades': 'aggtrades.parquet',\n",
-    "    'bookdepth': 'bookdepth.parquet',\n",
-    "    'indexpriceklines': 'indexpriceklines.parquet',\n",
-    "    'klines': 'klines.parquet',\n",
-    "    'markpriceklines': 'markpriceklines.parquet',\n",
-    "    'metrics': 'metrics.parquet',\n",
-    "    'premiumindexklines': 'premiumindexklines.parquet',\n",
-    "    'trades': 'trades.parquet',\n",
+    "# Dictionary mapping dataset keys to subfolders located in `data_dir`\n",
+    "dataset_folders = {\n",
+    "    'aggtrades': Path('aggTrades'),\n",
+    "    'bookdepth': Path('bookDepth'),\n",
+    "    'indexpriceklines': Path('indexPriceKlines'),\n",
+    "    'klines': Path('klines'),\n",
+    "    'markpriceklines': Path('markPriceKlines'),\n",
+    "    'metrics': Path('metrics'),\n",
+    "    'premiumindexklines': Path('premiumIndexKlines'),\n",
+    "    'trades': Path('trades'),\n",
     "}\n",
     "\n",
     "# Column names for each dataset\n",
@@ -89,18 +90,13 @@
    "outputs": [],
    "source": [
     "def load_dataset(key):\n",
-    "    # Load a dataset given its key. Supports Parquet and CSV formats.\n",
-    "    # Ensures column names match the expected schema defined in `cols`.\n",
-    "    file_name = files[key]\n",
-    "    file_path = os.path.join(data_dir, file_name)\n",
-    "    \n",
-    "    if file_name.lower().endswith('.parquet'):\n",
-    "        df = pd.read_parquet(file_path)\n",
-    "    elif file_name.lower().endswith('.csv'):\n",
-    "        df = pd.read_csv(file_path, header=None, names=cols[key])\n",
-    "    else:\n",
-    "        raise ValueError(f'Unsupported file extension for {file_name}')\n",
-    "    \n",
+    "    \"\"\"Load and concatenate all Parquet files for the given dataset key.\"\"\"\n",
+    "    folder_path = data_dir / dataset_folders[key]\n",
+    "    parquet_files = sorted(folder_path.glob('*.parquet'))\n",
+    "    if not parquet_files:\n",
+    "        raise FileNotFoundError(f'No Parquet files found in {folder_path}')\n",
+    "    df = pd.concat((pd.read_parquet(p) for p in parquet_files), ignore_index=True)\n",
+    "\n",
     "    # Enforce correct column names\n",
     "    if list(df.columns) != cols[key]:\n",
     "        df.columns = cols[key]\n",
@@ -116,7 +112,7 @@
    "source": [
     "# Load each dataset and display the first few rows\n",
     "datasets = {}\n",
-    "for key in files:\n",
+    "for key in dataset_folders:\n",
     "    print(f'Loading {key}...')\n",
     "    datasets[key] = load_dataset(key)\n",
     "    display(datasets[key].head())\n"


### PR DESCRIPTION
## Summary
- Represent dataset subfolders using `pathlib.Path` for safer path joins
- Keep column schema enforcement in `load_dataset`

## Testing
- `python -m json.tool binance_forecasting.ipynb > /tmp/nb.json && head /tmp/nb.json`
- `python - <<'PY'
import json, ast, sys
nb=json.load(open('binance_forecasting.ipynb'))
for i,cell in enumerate(nb['cells']):
    if cell.get('cell_type')=='code':
        src=''.join(cell['source'])
        try:
            ast.parse(src)
        except SyntaxError as e:
            print('Syntax error in cell', i, e)
            sys.exit(1)
print('Syntax check passed')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b0986e28d08328b3b266bc7b716f3a