### PR TITLE
Refactor dataset loading in forecasting notebook

### DIFF
--- a/binance_forecasting.ipynb
+++ b/binance_forecasting.ipynb
@@ -31,9 +31,11 @@
    "source": [
     "# Standard libraries\n",
     "import os\n",
+    "from pathlib import Path\n",
     "import pandas as pd\n",
     "import numpy as np\n",
-    "from datetime import datetime\n"
+    "from datetime import datetime\n",
+    "import dask.dataframe as dd\n"
    ]
   },
   {
@@ -46,7 +48,7 @@
     "# Path to your data directory on Google Drive\n",
     "# Update this path to where you've stored the Binance data files\n",
     "# For example: '/content/drive/MyDrive/binance_data'\n",
-    "data_dir = '/content/drive/MyDrive/binance_data'\n"
+    "data_dir = Path('/content/drive/MyDrive/binance_data')\n"
    ]
   },
   {
@@ -56,16 +58,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Dictionary mapping dataset keys to file names located in `data_dir`\n",
-    "files = {\n",
-    "    'aggtrades': 'aggtrades.parquet',\n",
-    "    'bookdepth': 'bookdepth.parquet',\n",
-    "    'indexpriceklines': 'indexpriceklines.parquet',\n",
-    "    'klines': 'klines.parquet',\n",
-    "    'markpriceklines': 'markpriceklines.parquet',\n",
-    "    'metrics': 'metrics.parquet',\n",
-    "    'premiumindexklines': 'premiumindexklines.parquet',\n",
-    "    'trades': 'trades.parquet',\n",
+    "# Dictionary mapping dataset keys to subfolders located in `data_dir`\n",
+    "dataset_folders = {\n",
+    "    'aggtrades': Path('aggTrades'),\n",
+    "    'bookdepth': Path('bookDepth'),\n",
+    "    'indexpriceklines': Path('indexPriceKlines'),\n",
+    "    'klines': Path('klines'),\n",
+    "    'markpriceklines': Path('markPriceKlines'),\n",
+    "    'metrics': Path('metrics'),\n",
+    "    'premiumindexklines': Path('premiumIndexKlines'),\n",
+    "    'trades': Path('trades'),\n",
     "}\n",
     "\n",
     "# Column names for each dataset\n",
@@ -89,22 +91,16 @@
    "outputs": [],
    "source": [
     "def load_dataset(key):\n",
-    "    # Load a dataset given its key. Supports Parquet and CSV formats.\n",
-    "    # Ensures column names match the expected schema defined in `cols`.\n",
-    "    file_name = files[key]\n",
-    "    file_path = os.path.join(data_dir, file_name)\n",
-    "    \n",
-    "    if file_name.lower().endswith('.parquet'):\n",
-    "        df = pd.read_parquet(file_path)\n",
-    "    elif file_name.lower().endswith('.csv'):\n",
-    "        df = pd.read_csv(file_path, header=None, names=cols[key])\n",
-    "    else:\n",
-    "        raise ValueError(f'Unsupported file extension for {file_name}')\n",
-    "    \n",
+    "    \"\"\"Load all Parquet files for the given dataset key as a lazy Dask DataFrame.\"\"\"\n",
+    "    folder_path = data_dir / dataset_folders[key]\n",
+    "    parquet_files = sorted(folder_path.glob('*.parquet'))\n",
+    "    if not parquet_files:\n",
+    "        raise FileNotFoundError(f'No Parquet files found in {folder_path}')\n",
+    "    df = dd.read_parquet([str(p) for p in parquet_files])\n",
     "    # Enforce correct column names\n",
     "    if list(df.columns) != cols[key]:\n",
-    "        df.columns = cols[key]\n",
-    "    return df\n"
+    "        df = df.rename(columns=dict(zip(df.columns, cols[key])))\n",
+    "    return df"
    ]
   },
   {
@@ -116,10 +112,11 @@
    "source": [
     "# Load each dataset and display the first few rows\n",
     "datasets = {}\n",
-    "for key in files:\n",
+    "for key in dataset_folders:\n",
     "    print(f'Loading {key}...')\n",
-    "    datasets[key] = load_dataset(key)\n",
-    "    display(datasets[key].head())\n"
+    "    df = load_dataset(key)\n",
+    "    datasets[key] = df\n",
+    "    display(df.head().compute())"
    ]
   },
   {
@@ -133,23 +130,23 @@
     "# Kline-like data: convert open_time and close_time (milliseconds)\n",
     "for key in ['indexpriceklines','klines','markpriceklines','premiumindexklines']:\n",
     "    df = datasets[key]\n",
-    "    df['open_time'] = pd.to_datetime(df['open_time'], unit='ms')\n",
-    "    df['close_time'] = pd.to_datetime(df['close_time'], unit='ms')\n",
+    "    df['open_time'] = dd.to_datetime(df['open_time'], unit='ms')\n",
+    "    df['close_time'] = dd.to_datetime(df['close_time'], unit='ms')\n",
     "    datasets[key] = df\n",
     "\n",
     "# Metrics: convert create_time to datetime\n",
-    "datasets['metrics']['create_time'] = pd.to_datetime(datasets['metrics']['create_time'], unit='ms')\n",
+    "datasets['metrics']['create_time'] = dd.to_datetime(datasets['metrics']['create_time'], unit='ms')\n",
     "\n",
     "# Book depth: convert timestamp\n",
-    "datasets['bookdepth']['timestamp'] = pd.to_datetime(datasets['bookdepth']['timestamp'], unit='ms')\n",
+    "datasets['bookdepth']['timestamp'] = dd.to_datetime(datasets['bookdepth']['timestamp'], unit='ms')\n",
     "\n",
     "# Agg trades: convert transact_time\n",
-    "datasets['aggtrades']['transact_time'] = pd.to_datetime(datasets['aggtrades']['transact_time'], unit='ms')\n",
+    "datasets['aggtrades']['transact_time'] = dd.to_datetime(datasets['aggtrades']['transact_time'], unit='ms')\n",
     "\n",
     "# Trades: convert time\n",
-    "datasets['trades']['time'] = pd.to_datetime(datasets['trades']['time'], unit='ms')\n",
+    "datasets['trades']['time'] = dd.to_datetime(datasets['trades']['time'], unit='ms')\n",
     "\n",
-    "print('Timestamps converted.')\n"
+    "print('Timestamps converted.')"
    ]
   },
   {
@@ -161,7 +158,7 @@
    "source": [
     "# Example: Resample klines to 15-minute bars\n",
     "# If your klines are already 1-minute bars, this aggregates them to 15-minute intervals\n",
-    "price_df = datasets['klines'][['open_time','open','high','low','close','volume','quote_volume']].copy()\n",
+    "price_df = datasets['klines'][['open_time','open','high','low','close','volume','quote_volume']].compute()\n",
     "price_df = price_df.set_index('open_time').sort_index()\n",
     "\n",
     "price_15m = price_df.resample('15T').agg({\n",
@@ -173,7 +170,7 @@
     "    'quote_volume': 'sum'\n",
     "}).dropna()\n",
     "\n",
-    "price_15m.head()\n"
+    "price_15m.head()"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Load Binance datasets lazily with Dask to avoid exhausting RAM
- Convert timestamp handling to Dask and compute only when needed

## Testing
- `python -m json.tool binance_forecasting.ipynb | head`
- `python - <<'PY'
import json, ast, sys
nb=json.load(open('binance_forecasting.ipynb'))
for i,cell in enumerate(nb['cells']):
    if cell.get('cell_type')=='code':
        src=''.join(cell['source'])
        try:
            ast.parse(src)
        except SyntaxError as e:
            print('Syntax error in cell', i, e)
            sys.exit(1)
print('Syntax check passed')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b0986e28d08328b3b266bc7b716f3a